### PR TITLE
BUG: Revert to "old-style" passing of LAMMPS neighbor list to Atomistica, closes #14

### DIFF
--- a/src/lammps/pair_style/pair_atomistica.cpp
+++ b/src/lammps/pair_style/pair_atomistica.cpp
@@ -429,18 +429,21 @@ void PairAtomistica::Atomistica_neigh()
   // Map seed and last arrays to point to the appropriate position in the
   // native LAMMPS neighbor list. This avoids copying the full list.
 
+  Atomistica_neighb_ = NULL;
+
   // Seed is reported relative to the lowest neighbor pointer value. What is
   // passed to Atomistica is a Fortran array that encloses all neighbors, from
   // the lowest to the highest pointer value. This is necessary because the
   // neigbor list in LAMMPS is not necessarily consecutive in memory.
-  Atomistica_neighb_ = firstneigh[ilist[0]];
-  Atomistica_neighb_endptr_ = NULL;
-  for (ii = 0; ii < inum; ii++) {
-    i = ilist[ii];
-    Atomistica_neighb_ = std::min(Atomistica_neighb_, firstneigh[i]);
-    Atomistica_neighb_endptr_ = std::max(Atomistica_neighb_endptr_,
-                                         firstneigh[i]+numneigh[i]);
-  }
+
+  // Atomistica_neighb_ = firstneigh[ilist[0]];
+  // Atomistica_neighb_endptr_ = NULL;
+  // for (ii = 0; ii < inum; ii++) {
+  //   i = ilist[ii];
+  //   Atomistica_neighb_ = std::min(Atomistica_neighb_, firstneigh[i]);
+  //   Atomistica_neighb_endptr_ = std::max(Atomistica_neighb_endptr_,
+  //                                        firstneigh[i]+numneigh[i]);
+  // }
 
   // Fill seed and last arrays.
   Atomistica_nneighb_ = 0;
@@ -532,8 +535,9 @@ void PairAtomistica::FAtomistica(int eflag, int vflag)
 
   // set pointers in neighbor list object
   neighbors_set_pointers(neighbors_,nall,Atomistica_seed_,Atomistica_last_,
-                         Atomistica_neighb_endptr_-Atomistica_neighb_+1,Atomistica_neighb_);
-
+                         // Atomistica_neighb_endptr_-Atomistica_neighb_+1,Atomistica_neighb_);
+			 Atomistica_nneighb_,Atomistica_neighb_);
+			 
   int ierror;
   epot = 0.0;
   class_->energy_and_forces(potential_,particles_,neighbors_,&epot,&f[0][0],

--- a/src/lammps/pair_style/pair_atomistica.h
+++ b/src/lammps/pair_style/pair_atomistica.h
@@ -69,7 +69,7 @@ class PairAtomistica : public Pair {
   intptr_t *Atomistica_seed_;
   intptr_t *Atomistica_last_;
   int *Atomistica_neighb_;
-  int *Atomistica_neighb_endptr_;
+  // int *Atomistica_neighb_endptr_;
   int Atomistica_nneighb_;
 
   int *mask_;


### PR DESCRIPTION
This bug fix expresses the internal Atomistica neighbor list in terms of pointers, i.e. difference to memory location NULL. This breaks on BlueGene Q when compiling with the XL compiler suite. The alternative (override by this commit) was to express it relative to some memory location encountered in the LAMMPS neighbor list. This worked on BlueGene Q but lead to occasional hangs (of unknown origin) on Intel platforms. We revert here to the old-style because the BlueGene Q platform has been discontinued.