### PR TITLE
Use current module setting instead of the environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@
 # Python files #
 ################
 # setup.py working directory
-#build
+build
 # sphinx build directory
 doc/_build
 # setup.py dist directory

--- a/src/python/atomistica/hardware.py
+++ b/src/python/atomistica/hardware.py
@@ -57,13 +57,11 @@ _hardware_info = {
     "nemo": {
         "cores_per_node": 20,
         "loginnodes": [r"login1.nemo.privat"],
-        'modules': ['mpi/impi', 'numlib/mkl', 'devel/python/3.6.0'],
         'scheduler': moab,
     },
     "justus": {
         "cores_per_node": 16,
         "loginnodes": [r"login??"],
-        'modules': ['mpi/impi'],
         'scheduler': moab,
     }
 }
@@ -188,15 +186,16 @@ class ComputeCluster:
         if set['mail'] is not None:
             print(c + '--mail-user=' + set['mail'], file=f)
         print(c + d['mailtype'], file=f)
-        if 'modules' in self.data:
-            for module in self.data['modules']:
-                print('module load', module, file=f)
         print('cd', set['wd'], file=f)
+
+        # atomistica uses OMP for parallelization
         print('export OMP_NUM_THREADS=$PBS_NP', file=f)
-        print(('export LD_LIBRARY_PATH=' + env['LD_LIBRARY_PATH'] +
-               ':$LD_LIBRARY_PATH'), file=f)
-        print('export PYTHONPATH=' + env['PYTHONPATH'] + ':$PYTHONPATH',
-              file=f)
+
+        # copy current module environment
+        print('export MODULEPATH=' + env['MODULEPATH'], file=f)
+        for module in env['LOADEDMODULES'].split(':'):
+            print('module load', module, file=f)
+
         print('python', set['script'], end=' ', file=f)
         if 'parameters' in set:
             print(set['parameters'], end=' ', file=f)

--- a/src/python/tools/a_run.py
+++ b/src/python/tools/a_run.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # ======================================================================
 # Atomistica - Interatomic potential library and molecular dynamics code
 # https://github.com/Atomistica/atomistica
@@ -18,7 +19,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # ======================================================================
-#!/usr/bin/env python
 # Emacs: treat this as -*- python -*-
 
 from __future__ import print_function


### PR DESCRIPTION
The environment changed on the Nemo cluster. The new way of writing a submission script does not use preset modules, but rather copies the current module setting. This should be more flexible to future changes and should also be transferable to other HPC systems using the module environment.