### PR TITLE
BUG: EAM tables have wrong starting point

### DIFF
--- a/src/potentials/eam/tabulated_eam.f90
+++ b/src/potentials/eam/tabulated_eam.f90
@@ -188,9 +188,9 @@ contains
 
     this%cutoff     = cutoff
 
-    call read(this%fF, f, nF, dF, dF)
-    call read(this%fZ, f, nr, dr, dr)
-    call read(this%frho, f, nr, dr, dr)
+    call read(this%fF, f, nF, 0.0_DP, dF)
+    call read(this%fZ, f, nr, 0.0_DP, dr)
+    call read(this%frho, f, nr, 0.0_DP, dr)
 
     call prlog("     cutoff(fZ)    = " // this%fZ%cut)
     call prlog("     cutoff(frho)  = " // this%frho%cut)


### PR DESCRIPTION
When reading the tabulated EAM potentials from file, the starting point `x0` is set to `dr` (pair potential and electron density) or `drho` (embedding function), where `dr` and `drho` are the grid spacings in distance and density space, respectively. However, EAM tables are tabulated for `[0, 1, 2, ... Nr]  * dr` and `[0, 1, 2, ... Nrho-1] * drho`, where `Nr` and `Nrho` is the number of points in distance and density space, respectively. Therefore, the first value in the table corresponds to `r=0` and `rho=0`, not `dr` and `drho`, respectively!