### PR TITLE
Config files for GCC version 10.x

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -41,6 +41,8 @@ Authors and contributors
 * Michael Walter  
   University of Freiburg
 
+* Tamas K Stenczel, University of Cambridge
+
 Parts of this code have been adopted from libAtoms.
 See http://www.libatoms.org/ for more information on contributors to
 libAtoms.

--- a/setup.cfg.gnu10
+++ b/setup.cfg.gnu10
@@ -1,0 +1,21 @@
+# Configuration file for the GNU Compiler Collection version 10 (gcc/gfortran).
+# Rename to setup.cfg.
+
+[config_fc]
+fcompiler=gfortran
+f90flags=-cpp -fPIC -ffree-form -ffree-line-length-none -x f95-cpp-input
+f77flags=-cpp -fPIC -x f77-cpp-input -fallow-argument-mismatch
+
+[build_ext]
+libraries=gfortran
+
+# See the docstring in versioneer.py for instructions. Note that you must
+# re-run 'versioneer.py setup' after changing this section, and commit the
+# resulting files.
+
+[versioneer]
+VCS = git
+style = pep440
+versionfile_source = src/python/atomistica/_version.py
+versionfile_build = atomistica/_version.py
+tag_prefix =

--- a/setup.cfg.gnu10_omp
+++ b/setup.cfg.gnu10_omp
@@ -1,0 +1,22 @@
+# Configuration file for the GNU Compiler Collection version 10 (gcc/gfortran) with OpenMP
+# parallelization.
+# Rename to setup.cfg.
+
+[config_fc]
+fcompiler=gfortran
+f90flags=-cpp -fPIC -ffree-form -ffree-line-length-none -x f95-cpp-input -fopenmp
+f77flags=-cpp -fPIC -x f77-cpp-input -fallow-argument-mismatch
+
+[build_ext]
+libraries=gomp,gfortran
+
+# See the docstring in versioneer.py for instructions. Note that you must
+# re-run 'versioneer.py setup' after changing this section, and commit the
+# resulting files.
+
+[versioneer]
+VCS = git
+style = pep440
+versionfile_source = src/python/atomistica/_version.py
+versionfile_build = atomistica/_version.py
+tag_prefix =

--- a/src/gen_versioninfo.sh
+++ b/src/gen_versioninfo.sh
@@ -1,8 +1,14 @@
 #! /bin/bash
 
 if [ ! -e $1/../setup.cfg ]; then
-  echo "Copying default setup.cfg..."
-  cp $1/../setup.cfg.gnu $1/../setup.cfg
+  if [ "$(gcc --version | awk '/gcc/ {print $4} {print "10.0.0"}' | sort -V | head -n 1)" == "10.0.0" ]; then
+    echo "Copying default setup.cfg... GCC-10"
+    cp $1/../setup.cfg.gnu10 $1/../setup.cfg
+  else
+    echo "Copying default setup.cfg..."
+    cp $1/../setup.cfg.gnu $1/../setup.cfg
+  fi
+
 fi
 
 atomistica_revision=$( cd $1/.. ; python3 -c "import versioneer; print(versioneer.get_version())")

--- a/src/gen_versioninfo.sh
+++ b/src/gen_versioninfo.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 if [ ! -e $1/../setup.cfg ]; then
-  if [ "$(gcc --version | awk '/gcc/ {print $4} {print "10.0.0"}' | sort -V | head -n 1)" == "10.0.0" ]; then
+  if [[ "$(gcc --version | awk '/gcc/ {print $4} {print "10.0.0"}' | sort -V | head -n 1)" == "10.0.0" ]]; then
     echo "Copying default setup.cfg... GCC-10"
     cp $1/../setup.cfg.gnu10 $1/../setup.cfg
   else

--- a/src/gen_versioninfo.sh
+++ b/src/gen_versioninfo.sh
@@ -1,12 +1,12 @@
 #! /bin/bash
 
 if [ ! -e $1/../setup.cfg ]; then
-  if [[ "$(gcc --version | awk '/gcc/ {print $4} {print "10.0.0"}' | sort -V | head -n 1)" == "10.0.0" ]]; then
-    echo "Copying default setup.cfg... GCC-10"
-    cp $1/../setup.cfg.gnu10 $1/../setup.cfg
-  else
+  if [[ "$(gcc --version | awk '/gcc/ {print $4} {print "10.0.0"}' | sort -V | tail -n 1)" == "10.0.0" ]]; then
     echo "Copying default setup.cfg..."
     cp $1/../setup.cfg.gnu $1/../setup.cfg
+  else
+    echo "Copying default setup.cfg... GCC-10"
+    cp $1/../setup.cfg.gnu10 $1/../setup.cfg
   fi
 
 fi

--- a/src/gen_versioninfo.sh
+++ b/src/gen_versioninfo.sh
@@ -1,14 +1,8 @@
 #! /bin/bash
 
 if [ ! -e $1/../setup.cfg ]; then
-  if [[ "$(gcc --version | awk '/gcc/ {print $4} {print "10.0.0"}' | sort -V | tail -n 1)" == "10.0.0" ]]; then
-    echo "Copying default setup.cfg..."
-    cp $1/../setup.cfg.gnu $1/../setup.cfg
-  else
-    echo "Copying default setup.cfg... GCC-10"
-    cp $1/../setup.cfg.gnu10 $1/../setup.cfg
-  fi
-
+  echo "Copying default setup.cfg..."
+  cp $1/../setup.cfg.gnu10 $1/../setup.cfg
 fi
 
 atomistica_revision=$( cd $1/.. ; python3 -c "import versioneer; print(versioneer.get_version())")


### PR DESCRIPTION
Include separate config files for GCC version 10, so that automated builds are easier to do on that version

The default config file is now the gcc 10 one, because this is backwards compatible, the earlier versions don't raise the argument mismatch anyways by default.

should clean up #39 