### PR TITLE
MAINT: update request of neighbor list in lammps interface

### DIFF
--- a/src/lammps/pair_style/pair_atomistica.cpp
+++ b/src/lammps/pair_style/pair_atomistica.cpp
@@ -51,7 +51,6 @@
 #include "comm.h"
 #include "neighbor.h"
 #include "neigh_list.h"
-#include "neigh_request.h"
 #include "memory.h"
 #include "error.h"
 #include "update.h"
@@ -308,10 +307,7 @@ void PairAtomistica::init_style()
 
   // need a full neighbor list
 
-  int irequest = neighbor->request(this);
-  neighbor->requests[irequest]->half = 0;
-  neighbor->requests[irequest]->full = 1;
-  neighbor->requests[irequest]->ghost = 1;
+  neighbor->add_request(this,NeighConst::REQ_FULL|NeighConst::REQ_GHOST);
 
   // find potential class in Atomistica potential database
 


### PR DESCRIPTION
I did not succeed to compile the latest stable release of lammps with the current version of atomistica. The reason for this seems to be how pair_atomistica.cpp requests the neighbor list. 
Updating pair_atomistica.cpp in analogy to the updates of other pair styles (see https://github.com/lammps/lammps/commit/a0996da644839534808f6efe8d9d8d0844585aaf) solves this problem.

